### PR TITLE
とりあえず動くようにしてみた

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-    "presets": ["es2015"],
+    "presets": [
+        "es2015",
+        "power-assert"
+    ],
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,24 +9,26 @@ module.exports = function(config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha'],
+    frameworks: ['mocha', 'power-assert', 'commonjs'],
 
-      
     // list of files / patterns to load in the browser
     files: [
-      // 'public/js/*.js',
-      'test/*.js'
+      'public/js/*.js',
+      'test/*.js',
     ],
 
 
     // list of files / patterns to exclude
     exclude: [
+      'public/js/fraction.js'
     ],
 
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
+      'test/**/*.js': ['babel', 'commonjs'],
+      'public/js/*.js': ['babel', 'commonjs']
     },
 
 
@@ -42,7 +44,7 @@ module.exports = function(config) {
         opts: 'test/mocha.opts'
       }
     },
-    
+
 
     // web server port
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "babel-preset-power-assert": "^1.0.0",
     "express": "~3.3.4",
+    "karma-commonjs": "^1.0.0",
     "mocha-reporter": "^0.1.1",
     "power-assert": "^1.4.4"
   },
@@ -14,9 +16,11 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",
     "karma": "^2.0.0",
+    "karma-babel-preprocessor": "^7.0.0",
     "karma-firefox-launcher": "^1.1.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
+    "karma-power-assert": "^1.0.0",
     "karma-safari-launcher": "^1.0.0",
     "mocha": "^4.1.0"
   }

--- a/test/util.js
+++ b/test/util.js
@@ -1,4 +1,4 @@
-import assert from 'power-assert';
+// import assert from 'power-assert';
 import { foo } from "../public/js/util";
 
 describe('Foo', function () {


### PR DESCRIPTION
とりあえず、動くようにしただけ。本設定は別におすすめしない。

* mochaではテストが動かなくなってます(import assert from 'power-assert'をけずったため)
* ブラウザでテストしなくてもいいよ。nodejsで動けば問題なし -> mochaのままでよし
* ブラウザだけでテストすればいいよ。nodejsで動く必要ない -> この設定も微妙なので、webpackなりrollupでimportを処理したものをkarmaでtestするほうがよいかも
* avaとかjestのほうがよいかもしれないけど使ったこと無い